### PR TITLE
Whitelist "as24-survey-opt-out" cookie

### DIFF
--- a/src/js/showcar-clean-cookies.js
+++ b/src/js/showcar-clean-cookies.js
@@ -18,6 +18,7 @@ const whiteList = [
     'S24UT',
     'webxtest',
     'testrun',
+    'as24-survey-opt-out',
     '__utma',
     '__utmz',
     'optimizelySegments',


### PR DESCRIPTION
This cookie is used to disable marketing surveys for our automated tests.