### PR TITLE
Lightbox background shift fix

### DIFF
--- a/src/06-components/atoms/lightbox/lightbox.js
+++ b/src/06-components/atoms/lightbox/lightbox.js
@@ -1,8 +1,9 @@
 import registerElement from '../../../07-utilities/helpers.js';
 
-export default function(tagName) {
+export default function (tagName) {
     const onOpenCallbacks = [];
     const onCloseCallbacks = [];
+    let scrollbarWidth;
 
     function attachedCallback() {
         let lb = {
@@ -16,6 +17,7 @@ export default function(tagName) {
 
         const id = this.id || '';
         const openElements = Array.from(document.querySelectorAll('[data-lightbox-open="' + id + '"]'));
+        scrollbarWidth = measureScrollbarWidth();
 
         openElements.forEach(el => {
             el.addEventListener('click', () => show(lb, el), false);
@@ -57,7 +59,9 @@ export default function(tagName) {
             });
         }
 
-        document.querySelector('html').classList.add('sc-unscroll');
+        const html = document.querySelector('html');
+        html.classList.add('sc-unscroll');
+        html.style.marginRight = scrollbarWidth ? `${scrollbarWidth}px` : 0;
 
         setTimeout(() => {
             lb.overlay.classList.add('sc-lightbox--fadein');
@@ -71,7 +75,9 @@ export default function(tagName) {
      */
     const hide = (lb, e, executeOnCloseCallback = true) => {
         // e.stopPropagation();
-        document.querySelector('html').classList.remove('sc-unscroll');
+        const html = document.querySelector('html');
+        html.classList.remove('sc-unscroll');
+        html.style.marginRight = 0; // reset margin
 
         if (e.target === lb.overlay || lb.close.includes(e.target) || e.keyCode === 27) {
             e.preventDefault();
@@ -91,6 +97,10 @@ export default function(tagName) {
     const registerOnOpenCallback = cb => onOpenCallbacks.push(cb);
 
     const registerOnCloseCallback = cb => onCloseCallbacks.push(cb);
+
+    function measureScrollbarWidth() {
+        return window && document && (window.innerWidth - document.documentElement.clientWidth) || 0;
+    }
 
     registerElement(
         {

--- a/src/06-components/molecules/notification/notification.scss
+++ b/src/06-components/molecules/notification/notification.scss
@@ -43,7 +43,7 @@ $types: (
   background-position: $L map-get($type, background-position-y);
 }
 
-as24-notification {
+as24-notification, .sc-as24-notification {
   display: block;
   overflow: hidden;
   width: 100%;


### PR DESCRIPTION
## Description

- Updates lightbox to measure and counter for hiding-scrollbar shifting the background
- Unrelated: as24-notification css extension


## Risks
- low Could leave html in a different shifted state after lightbox is closed IF html had original `margin-right` shift (seems very unlikely) 
