### PR TITLE
Fix lightbox triggering scroll fixes on hide call

### DIFF
--- a/src/06-components/atoms/lightbox/lightbox.js
+++ b/src/06-components/atoms/lightbox/lightbox.js
@@ -74,12 +74,14 @@ export default function (tagName) {
      * @param {boolean} executeOnCloseCallback executeOnCloseCallback Hide method gets called twice when clicking on close button, but we want to run close callback only-once
      */
     const hide = (lb, e, executeOnCloseCallback = true) => {
-        const html = document.querySelector('html');
-        html.classList.remove('sc-unscroll');
-        html.style.marginRight = 0; // reset margin
-
         if (e.target === lb.overlay || lb.close.includes(e.target) || e.keyCode === 27) {
             e.preventDefault();
+
+            // Unapply scrollbar fixes
+            const html = document.querySelector('html');
+            html.classList.remove('sc-unscroll');
+            html.style.marginRight = 0; // reset margin
+
             lb.container.classList.remove('sc-lightbox__container--visible');
             lb.parent.appendChild(lb.container);
             if (lb.overlay) {


### PR DESCRIPTION
## Description
Current lightbox was wrongly applying removal on `sc-unscroll` class and margin fixes even for the case that the lightbox would not be closed (inside clicks). This fixes it


## Risks
- low, only affects lightbox
