### PR TITLE
Upgrade document-register-element

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "main": "src/js/showcar-ui.js",
   "dependencies": {
-    "document-register-element": "^0.5.4",
+    "document-register-element": "^1.13.2",
     "dom4": "^1.8.5",
     "es6-collections": "^0.5.6",
     "lazysizes": "^4.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2797,9 +2797,12 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
-document-register-element@^0.5.4:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/document-register-element/-/document-register-element-0.5.4.tgz#df6b57fbb8e141123e5f61acf382d6bb78c02bce"
+document-register-element@^1.13.2:
+  version "1.13.3"
+  resolved "https://registry.yarnpkg.com/document-register-element/-/document-register-element-1.13.3.tgz#81e44360a2e01ad0a56cf94bd1a7627e5cc2013e"
+  integrity sha512-hfggFwSF2bRJG2NLvzpMPLNOYaw3WC/cQ3ZWIl0zxiwfIimNaME53Mf6XFFVtQXpsAdCOf/Yw7tdQXIoSOvhTg==
+  dependencies:
+    lightercollective "^0.3.0"
 
 dom-serialize@^2.2.0:
   version "2.2.1"
@@ -5799,6 +5802,11 @@ liftoff@^2.1.0, liftoff@^2.5.0:
     object.map "^1.0.0"
     rechoir "^0.6.2"
     resolve "^1.1.7"
+
+lightercollective@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/lightercollective/-/lightercollective-0.3.0.tgz#1f07638642ec645d70bdb69ab2777676f35a28f0"
+  integrity sha512-RFOLSUVvwdK3xA0P8o6G7QGXLIyy1L2qv5caEI7zXN5ciaEjbAriRF182kbsoJ1S1TgvpyGcN485fMky6qxOPw==
 
 limiter@^1.0.5:
   version "1.1.4"


### PR DESCRIPTION
## Description
This pull request upgrades the `document-register-element` module, enabling standard Custom Elements V1 (`window.customElements.define`) in addition to Custom Elements V0 (`document.registerElement`).

Upgrading this module will allow the existing use of `document.registerElement` to continue to work as more browsers remove support for Custom Elements V0. Most browsers natively support Custom Elements V1 already. Babel 7 natively supports the transpilation of Custom Elements V1 classes to ES5.

Error spikes relating to the use of `document.registerElement` in Firefox have been observed in the past on AutoScout24, hopefully upgrading this module and/or switching to Custom Elements V1 will reduce these errors.

[OSA](https://github.com/Scout24/OSA-One-Scout-Adlib/) is dependent on this upgrade as for the `as24` build target the `document-register-element` module is not included to prevent duplication.

## Risks
- [medium] Tracking issues (https://github.com/Scout24/showcar-ui/commit/6e315601b35d8a770014c6e7e157e92707d4dcc5) could be reintroduced.