### PR TITLE
Fix navigation subtitle for FF

### DIFF
--- a/src/06-components/organisms/navigation/navigation.scss
+++ b/src/06-components/organisms/navigation/navigation.scss
@@ -155,6 +155,8 @@
 
     span.subtitle {
       position: absolute;
+      left: 0;
+      padding-left: 24px;
       top: 47px; // Could be adjusted. Position relative to wrapping <li>
       height: $M + 2; // keep limited for hidden overflow
       color: $black-60;


### PR DESCRIPTION
Fixes in FF:
![Screenshot 2019-08-12 13 35 22](https://user-images.githubusercontent.com/1997390/62862440-1c136f80-bd06-11e9-9690-a3873bc7b750.png)
