### PR TITLE
Fix for navigation. Removes scroll arrows in Chrome, win

### DIFF
--- a/src/06-components/organisms/navigation/navigation.scss
+++ b/src/06-components/organisms/navigation/navigation.scss
@@ -158,7 +158,7 @@
       left: 0;
       padding-left: 24px;
       top: 47px; // Could be adjusted. Position relative to wrapping <li>
-      height: $M + 2; // keep limited for hidden overflow
+      height: $M + 4; // keep limited for hidden overflow
       color: $black-60;
       font-size: $M;
       overflow-x: hidden;


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1997390/62944924-f5286c80-bddd-11e9-922e-b28a2b0216f2.png)
/cc @AutoScout24/web-experience
