### PR TITLE
[ADS-2172] Add Faktor.io cookies to whitelist

### DIFF
--- a/src/js/showcar-clean-cookies.js
+++ b/src/js/showcar-clean-cookies.js
@@ -50,7 +50,11 @@ const whiteList = [
     'as24_identity',
     'noauth',
     'random',
-    'as24ArticleType'
+    'as24ArticleType',
+    '5c3e5f30-4d66-4a27-931d-61b7f4905dedcconsent',
+    '5c3e5f30-4d66-4a27-931d-61b7f4905dedeuconsent',
+    '5c3e5f30-4d66-4a27-931d-61b7f4905dedfaktorChecksum',
+    '5c3e5f30-4d66-4a27-931d-61b7f4905dedfaktorId'
 ];
 
 const deleteCookieByName = function(cookie) {


### PR DESCRIPTION
/cc @AutoScout24/web-experience

## Description
This pull request whitelists the cookies used by the new consent management platform Faktor.io.