### PR TITLE
Adds cross-domain tracking cookie for Auto-Abo to whitelist

### DIFF
--- a/src/js/showcar-clean-cookies.js
+++ b/src/js/showcar-clean-cookies.js
@@ -5,6 +5,7 @@ const whiteList = [
     '_gid',
     '_gat',
     'AMP_TOKEN',
+    'as24AutoAboLike2Drive',
     'as24-gtmSearchCrit',
     'as24Visitor',
     'culture',


### PR DESCRIPTION
/cc @AutoScout24/web-experience

## Description
Adds cookie to whitelist, it's used to track when a user visits an Auto-Abo listing detail page from an specific provider.


## Risks
- [low] 
